### PR TITLE
Change restart policy for web UI container

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -30,7 +30,7 @@ services:
 
   osn-discovery-webui:
     image: ghcr.io/kevincoakley/osn-discovery-webui:1.1.0
-    restart: always
+    restart: "no"
     volumes:
       - app-volume:/app/dist
     environment:


### PR DESCRIPTION
Web UI container would exit after running `npm run build`; with restart
policy set to "always", results in container constantly being restart.

Setting restart policy to "no" disables restarts to the container and
after testing, seems to be that the compiled build files are still
present in the shared volume `app-volume` after the web UI container
exits.